### PR TITLE
Remove double-offset calculations

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -11,5 +11,5 @@ app_server <- function( input, output, session ) {
   
   # Your application server logic 
   mod_cal_viewer_server("cal_viewer_ui_1")
-  mod_cal_entry_server("cal_entry_ui_1")
+  #mod_cal_entry_server("cal_entry_ui_1")
 }

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -21,8 +21,8 @@ app_ui <- function(request) {
       tabPanel(
         title = "Entry",
         value = "entry",
-        h1("The module goes here!"),
-        mod_cal_entry_ui("cal_entry_ui_1")
+        h1("Under Construction!")
+        #mod_cal_entry_ui("cal_entry_ui_1")
       )
     )
   )

--- a/R/mod_cal_viewer.R
+++ b/R/mod_cal_viewer.R
@@ -52,7 +52,7 @@ mod_cal_viewer_ui <- function(id){
           ns("time_zone"),
           label = "Select Time Zone",
           choices = process_raw_timezones(),
-          selected = "America/Los_Angeles",
+          selected = "America/New_York",
           options = shinyWidgets::pickerOptions(
             liveSearch = TRUE
           )
@@ -166,19 +166,21 @@ mod_cal_viewer_server <- function(id){
       req(cal_processed())
       req(input$entry_color)
       req(input$entry_font_color)
-      req(input$time_zone)
+     
+      # let the calendar render portion handle offsets / time conversion
+      # original time zone is America/New_York, so stick with that after parsing
+      new_zone <- "America/New_York"
       
-      # convert times to be the time zone selected
       cal_sub2 <- cal_processed() %>%
-        mutate(start = purrr::map_chr(start, ~time_parser(.x, orig_zone = "America/New_York", new_zone = input$time_zone, format = "%Y-%m-%d %H:%M:%S", convert_to_char = TRUE))) %>%
-        mutate(end = purrr::map_chr(end, ~time_parser(.x, orig_zone = "America/New_York", new_zone = input$time_zone, format = "%Y-%m-%d %H:%M:%S", convert_to_char = TRUE))) %>%
+        mutate(start = purrr::map_chr(start, ~time_parser(.x, orig_zone = "America/New_York", new_zone = new_zone, format = "%Y-%m-%d %H:%M:%S", convert_to_char = TRUE))) %>%
+        mutate(end = purrr::map_chr(end, ~time_parser(.x, orig_zone = "America/New_York", new_zone = new_zone, format = "%Y-%m-%d %H:%M:%S", convert_to_char = TRUE))) %>%
         select(., -videos_data, -start_time, -end_time, -category) %>%
         mutate(bgColor = ifelse(is.na(bgColor), input$entry_color, bgColor)) %>%
         mutate(color = ifelse(is.na(color), input$entry_font_color, color))
       
       if (input$streamer_select != "all") {
         cal_sub2 <- cal_sub2 %>%
-          filter(user_id == input$streamer_select)   
+          filter(user_id == input$streamer_select)
       }
 
       return(cal_sub2)

--- a/dev/03_deploy.R
+++ b/dev/03_deploy.R
@@ -57,21 +57,13 @@ library(gert)
 current_branch <- git_branch()
 app_name <- golem::get_golem_name()
 
-if (current_branch == "master") {
-    rsconnect::deployApp(
-        appName = app_name, 
-        appFileManifest = "dev/app_manifest.txt", 
-        launch.browser = FALSE, 
-        forceUpdate = TRUE
-    )
-} else if (current_branch == "dev") {
-    rsconnect::deployApp(
-        appName = paste0(app_name, "_dev"), 
-        appFileManifest = "dev/app_manifest.txt", 
-        launch.browser = FALSE, 
-        forceUpdate = TRUE
-    )
-} else {
-    message("Only the dev and main branches are deployable, nothing to do!")
+if (current_branch != "master") {
+    app_name <- paste0(app_name, "_dev")
 }
 
+rsconnect::deployApp(
+  appName = app_name, 
+  appFileManifest = "dev/app_manifest.txt", 
+  launch.browser = FALSE, 
+  forceUpdate = TRUE
+)

--- a/dev/run_dev.R
+++ b/dev/run_dev.R
@@ -1,5 +1,5 @@
 # Set options here
-options(golem.app.prod = FALSE) # TRUE = production mode, FALSE = development mode
+options(golem.app.prod = TRUE) # TRUE = production mode, FALSE = development mode
 
 # Detach all loaded packages and clean your environment
 golem::detach_all_attached()


### PR DESCRIPTION
This PR closes #23 by removing the offset calculation from the data processing step, and leaving the calculation to the `cal_timezone` function when rendering the calendar.